### PR TITLE
Dev

### DIFF
--- a/src/main/java/br/com/muritadb/dscommerce/entities/User.java
+++ b/src/main/java/br/com/muritadb/dscommerce/entities/User.java
@@ -1,0 +1,128 @@
+package br.com.muritadb.dscommerce.entities;
+
+import java.time.LocalDate;
+
+public class User {
+
+  private Long id;
+  private String name;
+  private String email;
+  private String phone;
+  private LocalDate birthDate;
+  private String password;
+
+  public User() {}
+
+  public User(Long id, String name, String email, String phone, LocalDate birthDate, String password) {
+    this.id = id;
+    this.name = name;
+    this.email = email;
+    this.phone = phone;
+    this.birthDate = birthDate;
+    this.password = password;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
+
+  public void setPhone(String phone) {
+    this.phone = phone;
+  }
+
+  public LocalDate getBirthDate() {
+    return birthDate;
+  }
+
+  public void setBirthDate(LocalDate birthDate) {
+    this.birthDate = birthDate;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((id == null) ? 0 : id.hashCode());
+    result = prime * result + ((name == null) ? 0 : name.hashCode());
+    result = prime * result + ((email == null) ? 0 : email.hashCode());
+    result = prime * result + ((phone == null) ? 0 : phone.hashCode());
+    result = prime * result + ((birthDate == null) ? 0 : birthDate.hashCode());
+    result = prime * result + ((password == null) ? 0 : password.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    User other = (User) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    if (name == null) {
+      if (other.name != null)
+        return false;
+    } else if (!name.equals(other.name))
+      return false;
+    if (email == null) {
+      if (other.email != null)
+        return false;
+    } else if (!email.equals(other.email))
+      return false;
+    if (phone == null) {
+      if (other.phone != null)
+        return false;
+    } else if (!phone.equals(other.phone))
+      return false;
+    if (birthDate == null) {
+      if (other.birthDate != null)
+        return false;
+    } else if (!birthDate.equals(other.birthDate))
+      return false;
+    if (password == null) {
+      if (other.password != null)
+        return false;
+    } else if (!password.equals(other.password))
+      return false;
+    return true;
+  }
+
+}

--- a/src/main/java/br/com/muritadb/dscommerce/entities/User.java
+++ b/src/main/java/br/com/muritadb/dscommerce/entities/User.java
@@ -2,8 +2,18 @@ package br.com.muritadb.dscommerce.entities;
 
 import java.time.LocalDate;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "tb_user")
 public class User {
 
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
   private String name;
   private String email;

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,12 @@
+# Configurações do banco de dados H2
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.password=
+
+#Configuracao do cliente web do banco h2
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+#Configuracao para mostrar o sql no console
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=dscommerce
+
+spring.profiles.active=test
+spring.jpa.open-in-view=false


### PR DESCRIPTION
This pull request introduces a new `User` entity class, adds database configuration for testing with H2, and updates the application properties to activate the test profile. The most important changes include the creation of the `User` class and the configuration for the H2 database.

### Entity Creation:
* [`src/main/java/br/com/muritadb/dscommerce/entities/User.java`](diffhunk://#diff-71204ead6a9db7557635486c59d6cc5507cf4359c680f548966ecaf7b103f160R1-R138): Created a new `User` entity class with fields `id`, `name`, `email`, `phone`, `birthDate`, and `password`. This class includes constructors, getters, setters, and overridden `hashCode` and `equals` methods.

### Database Configuration:
* [`src/main/resources/application-test.properties`](diffhunk://#diff-7262e6545724c8dbe1b3c64b35b6f9b737cf0aaf7242725378a0d6574e6bed19R1-R12): Added configurations for the H2 in-memory database for testing purposes, including enabling the H2 console and showing SQL statements in the console.
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R2-R4): Updated to activate the `test` profile and disable `open-in-view` for JPA.This pull request introduces a new `User` entity and updates the application properties to configure the H2 database for testing. The most important changes are the addition of the `User` entity class and the configuration adjustments for the H2 database.

Entity addition:

* [`src/main/java/br/com/muritadb/dscommerce/entities/User.java`](diffhunk://#diff-71204ead6a9db7557635486c59d6cc5507cf4359c680f548966ecaf7b103f160R1-R138): Added a new `User` entity class with fields for `id`, `name`, `email`, `phone`, `birthDate`, and `password`, along with corresponding getters, setters, and `hashCode` and `equals` methods.

Configuration updates:

* [`src/main/resources/application-test.properties`](diffhunk://#diff-7262e6545724c8dbe1b3c64b35b6f9b737cf0aaf7242725378a0d6574e6bed19R1-R12): Added H2 database configuration for testing, including datasource URL, username, and password, enabling the H2 console, and showing SQL in the console.
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R2-R4): Set the active profile to `test` and disabled `open-in-view` for JPA.