### PR TITLE
feat: add Order and Payment entities with relationships to User and O…

### DIFF
--- a/src/main/java/br/com/muritadb/dscommerce/entities/Order.java
+++ b/src/main/java/br/com/muritadb/dscommerce/entities/Order.java
@@ -1,0 +1,112 @@
+package br.com.muritadb.dscommerce.entities;
+
+import java.time.Instant;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "tb_order")
+public class Order {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(columnDefinition = "TIMESTAMP WITHOUT TIME ZONE")
+  private Instant moment;
+  private OrderStatus status;
+
+  @ManyToOne
+  @JoinColumn(name = "client_id")
+  private User client;
+
+
+  @OneToOne(mappedBy = "order", cascade = CascadeType.ALL)
+  private Payment payment;
+  
+  public User getClient() {
+    return client;
+  }
+
+  public void setClient(User client) {
+    this.client = client;
+  }
+
+  public Order() {
+    
+  }
+
+
+  public Order(Long id, Instant moment, OrderStatus status, User client,Payment payment) {
+    this.id = id;
+    this.moment = moment;
+    this.status = status;
+    this.client = client;
+    this.payment = payment;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Instant getMoment() {
+    return moment;
+  }
+
+  public void setMoment(Instant moment) {
+    this.moment = moment;
+  }
+
+  public OrderStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(OrderStatus status) {
+    this.status = status;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((id == null) ? 0 : id.hashCode());
+    result = prime * result + ((moment == null) ? 0 : moment.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Order other = (Order) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    if (moment == null) {
+      if (other.moment != null)
+        return false;
+    } else if (!moment.equals(other.moment))
+      return false;
+    return true;
+  }
+
+}

--- a/src/main/java/br/com/muritadb/dscommerce/entities/OrderStatus.java
+++ b/src/main/java/br/com/muritadb/dscommerce/entities/OrderStatus.java
@@ -1,0 +1,9 @@
+package br.com.muritadb.dscommerce.entities;
+
+public enum OrderStatus {
+  WAITING_PAYMENT, 
+  PAID, 
+  SHIPPED, 
+  DELIVERED, 
+  CANCELED
+}

--- a/src/main/java/br/com/muritadb/dscommerce/entities/Payment.java
+++ b/src/main/java/br/com/muritadb/dscommerce/entities/Payment.java
@@ -1,0 +1,101 @@
+package br.com.muritadb.dscommerce.entities;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "tb_payment")
+public class Payment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(columnDefinition = "TIMESTAMP WITHOUT TIME ZONE")
+  private Instant moment;
+
+
+
+  @OneToOne
+  @MapsId
+  private Order order;
+  
+  
+  
+  public Payment() {
+  }
+  
+
+
+  public Payment(Long id, Instant moment, Order order) {
+    this.id = id;
+    this.moment = moment;
+    this.order = order;
+  }
+
+
+
+  public Long getId() {
+    return id;
+  }
+  public void setId(Long id) {
+    this.id = id;
+  }
+  public Instant getMoment() {
+    return moment;
+  }
+  public void setMoment(Instant moment) {
+    this.moment = moment;
+  }
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((id == null) ? 0 : id.hashCode());
+    result = prime * result + ((moment == null) ? 0 : moment.hashCode());
+    return result;
+  }
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Payment other = (Payment) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    if (moment == null) {
+      if (other.moment != null)
+        return false;
+    } else if (!moment.equals(other.moment))
+      return false;
+    return true;
+  }
+
+
+
+  public Order getOrder() {
+    return order;
+  }
+
+
+
+  public void setOrder(Order order) {
+    this.order = order;
+  }
+
+  
+}

--- a/src/main/java/br/com/muritadb/dscommerce/entities/User.java
+++ b/src/main/java/br/com/muritadb/dscommerce/entities/User.java
@@ -1,11 +1,14 @@
 package br.com.muritadb.dscommerce.entities;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 @Entity
@@ -20,6 +23,10 @@ public class User {
   private String phone;
   private LocalDate birthDate;
   private String password;
+
+  @OneToMany(mappedBy = "client")
+  private List<Order> orders = new ArrayList<>();
+  
 
   public User() {}
 
@@ -133,6 +140,10 @@ public class User {
     } else if (!password.equals(other.password))
       return false;
     return true;
+  }
+
+  public List<Order> getOrders() {
+    return orders;
   }
 
 }


### PR DESCRIPTION
This pull request introduces new entities and relationships to the `dscommerce` application, focusing on orders and payments. The changes include the creation of new classes and the addition of relationships between existing classes.

### New Entities and Relationships:

* [`src/main/java/br/com/muritadb/dscommerce/entities/Order.java`](diffhunk://#diff-51a8d0deb0d68614bbae7008aaa81113cac27f99b455f317b643f152ef9f677eR1-R112): Created the `Order` entity with fields for `id`, `moment`, `status`, `client`, and `payment`, and added necessary annotations for JPA mapping.
* [`src/main/java/br/com/muritadb/dscommerce/entities/OrderStatus.java`](diffhunk://#diff-1dffd61ba0198bfb7400512381c51747647918f7fd99d4796cd5b7b3c9d2a79cR1-R9): Added the `OrderStatus` enum to represent the possible statuses of an order.
* [`src/main/java/br/com/muritadb/dscommerce/entities/Payment.java`](diffhunk://#diff-d905469d9951316faf1b92208bcfb34ded9e265487e8c37521192342168a33a6R1-R101): Created the `Payment` entity with fields for `id`, `moment`, and `order`, and added necessary annotations for JPA mapping.

### Updates to Existing Entities:

* [`src/main/java/br/com/muritadb/dscommerce/entities/User.java`](diffhunk://#diff-71204ead6a9db7557635486c59d6cc5507cf4359c680f548966ecaf7b103f160R4-R11): Updated the `User` entity to include a one-to-many relationship with the `Order` entity, and added a getter method for the `orders` field. [[1]](diffhunk://#diff-71204ead6a9db7557635486c59d6cc5507cf4359c680f548966ecaf7b103f160R4-R11) [[2]](diffhunk://#diff-71204ead6a9db7557635486c59d6cc5507cf4359c680f548966ecaf7b103f160R27-R30) [[3]](diffhunk://#diff-71204ead6a9db7557635486c59d6cc5507cf4359c680f548966ecaf7b103f160R145-R148)